### PR TITLE
PR4 SD1 HD2 2022

### DIFF
--- a/app/server/legtracker.js
+++ b/app/server/legtracker.js
@@ -88,8 +88,8 @@ app.get('/api/scrapeMeasures/:year/:mt', async (req, res) => {
         // eslint-disable-next-line no-console
         scrapedData.push({
           code: `${code}`,
-          measurePdfUrl: `${measurePdfUrl}`,
-          measureArchiveUrl: `${measureArchiveUrl}`,
+          measurePdfUrl: `$https://www.capitol.hawaii.gov{measurePdfUrl}`,
+          measureArchiveUrl: `https://www.capitol.hawaii.gov${measureArchiveUrl}`,
           measureTitle: `${measureTitle}`,
           reportTitle: `${reportTitle}`,
           description: `${description}`,


### PR DESCRIPTION
<p>RELATING TO THE SCRAPING OF THE WEBSITE AND HREF ATTRIBUTES.</p>
<b><p>BE IT ENACTED BY THE MAINTAINERS OF THIS REPO:</p></b>
	<p>SECTION 1. The maintainers find that, given the fact the website scraping accesses the DOM of the advreports page being hosted on a capitol.hawaii.gov website, the link elements on that page are not absolute. Accordingly, the purpose of this pull request is to allow the script to add an appropriate top-level domain name to the links pulled from this page.</p>
	<p>SECTION 2. File \Legislative-Scraper-Production-main\app\server\legtracker.js is amended as follows:<ol>
	<li>By amending the scrapedData push call by changing variable definition for measurePdfUrl to read:<br>
	"measurePdfUrl: `<b><i>https://www.capitol.hawaii.gov</i></b>${measurePdfUrl}`,"</li>
	<li>By amending the scrapedData push call by changing variable definition for measureArchiveUrl to read:<br> "measureArchiveUrl :`<b><i>https://www.capitol.hawaii.gov</i></b>${measureArchiveUrl}`,</li></ol></p>
	<p>SECTION 3. Code to be removed is bracketed and stricken. New code is italicized and bolded.</p>
	<p>SECTION 4. This pull request shall take effect upon its merge.</p>